### PR TITLE
Modified the behaviour of some basic arithmetic operators 

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -26,7 +26,7 @@ Example::
 Normal operations
 -----------------
 
-Some operations have been oveloaded for dictionaries so they can be done between superdicts as if they were numbers:
+Some operations have been overloaded for dictionaries so they can be done between superdicts as if they were numbers:
 
 Example data::
 
@@ -35,6 +35,43 @@ Example data::
     need = pt.SuperDict({'apples': 1, 'pears': 2, 'tomatoes': 1})
     left_need = need - have
     # {'pears': 1, 'tomatoes': 1}
+
+    mult_need_have = need * have
+    # {'apples': 1, 'pears': 2, 'tomatoes': 0}
+
+    add_need_have = need + have
+    # {'apples': 2, 'pears': 3, 'tomatoes': 1}
+
+These basic operations can also be done between superdicts and other values such as integers, floats and strings.
+
+Examples::
+
+    import pytups as pt
+    have = pt.SuperDict({'apples': 1, 'pears': 1, 'tomatoes': 0})
+    add_have = have + 1
+    # {'apples': 2, 'pears': 2, 'tomatoes': 1}
+
+    sub_have = have - 1
+    # {'apples': 0, 'pears': 0, 'tomatoes': -1}
+
+    mult_have = have * 2
+    # {'apples': 2, 'pears': 2, 'tomatoes': 0}
+
+    true_div_have = have / 2
+    # {'apples': 0.5, 'pears': 0.5, 'tomatoes': 0.0}
+
+    int_div_have = have // 2
+    # {'apples': 0, 'pears': 0, 'tomatoes': 0}
+
+And finally, if the value of the superdict os a list, the adding operator works as well.
+
+Example::
+
+    import pytups as pt
+    my_need = pt.SuperDict({'apples': [1, 2], 'pears': [1, 2], 'tomatoes': [0, 1]})
+    other_need = pt.SuperDict({'apples': [1, 1], 'pears': [1, 1], 'tomatoes': [1, 1]})
+    total_need = my_need + other_need
+    # {'apples': [1, 2, 1, 1], 'pears': [1, 2, 1, 1], 'tomatoes': [0, 1, 1, 1]}
 
 
 Filtering

--- a/pytups/superdict.py
+++ b/pytups/superdict.py
@@ -38,31 +38,58 @@ class SuperDict(dict, Generic[K, V], Mapping[K, V]):
     def __iter__(self) -> Iterator[K]:
         return dict.__iter__(self)
 
-    def __add__(self, other):
+    def __add__(self, other: Union[dict, int, float, str]) -> "SuperDict":
+        """
+        Applies the adding operator to the values in the SuperDict and another object.
+        This operation might raise a TypeError based on the types of the values of the SuperDict and the other object.
+        """
         return self.sapply(op.__add__, other)
 
     # def __radd__(self, other):
     #     return self.sapply(op.__add__, other)
 
-    def __sub__(self, other):
+    def __sub__(self, other: Union[dict, int, float, str]) -> "SuperDict":
+        """
+        Applies the substract operator to the values in the SuperDict and another object.
+        This operation might raise a TypeError based on the types of the values of the SuperDict and the other object.
+        """
         return self.sapply(op.__sub__, other)
 
     # def __rsub__(self, other):
     #     return other.sapply(op.__sub__, self)
 
-    def __mul__(self, other):
+    def __mul__(self, other: Union[dict, int, float, str]) -> "SuperDict":
+        """
+        Applies the multiply operator to the values in the SuperDict and another object.
+        This operation might raise a TypeError based on the types of the values of the SuperDict and the other object.
+        """
         return self.sapply(op.__mul__, other)
 
     # def __rmul__(self, other):
     #     return self.sapply(op.__mul__, other)
 
-    def __truediv__(self, other):
+    def __truediv__(self, other: Union[dict, int, float, str]) -> "SuperDict":
+        """
+        Applies the true division (float division) operator to the values in the SuperDict and another object.
+        This operation might raise a TypeError based on the types of the values of the SuperDict and the other object.
+        """
         return self.sapply(op.__truediv__, other)
 
-    def __floordiv__(self, other):
+    def __floordiv__(self, other: Union[dict, int, float, str]) -> "SuperDict":
+        """
+        Applies the floor division (integer division) operator to the values in the SuperDict and another object.
+        This operation might raise a TypeError based on the types of the values of the SuperDict and the other object.
+        """
         return self.sapply(op.__floordiv__, other)
 
-    def head(self):
+    def head(self) -> str:
+        """
+        Returns a string representation with the first pair of key values in the SuperDict, the last pair of key value
+        and the number of elements on the SuperDict.
+
+        :return: the head string representation of the SuperDict
+        :rtype: str
+        """
         if len(self) <= 2:
             return dict.__repr__(self)
         _keys = self.keys_l()
@@ -461,7 +488,7 @@ class SuperDict(dict, Generic[K, V], Mapping[K, V]):
         return SuperDict({k: func(k, *args, **kwargs) for k in self})
 
     def sapply(
-        self, func: Callable, other: Union[dict, int, float], *args, **kwargs
+        self, func: Callable, other: Union[dict, int, float, str], *args, **kwargs
     ) -> "SuperDict":
         """
         Applies function to both dictionaries.
@@ -469,15 +496,14 @@ class SuperDict(dict, Generic[K, V], Mapping[K, V]):
         It's like applying a function over the left join.
 
         :param callable func: function to apply.
-        :param Union[dict, int, float] other: either ar int or float to perform the operation over or another dictionary
+        :param Union[dict, int, float,s tr] other: either an int, a float, a string or another dictionary to
+          perform the operation over
         :return: new :py:class:`SuperDict`
         """
-        if isinstance(other, (int, float)):
-            other = {k: other for k in self}
+        if isinstance(other, (int, float, str)):
+            return self.vapply(lambda v: func(v, other, *args, **kwargs))
 
-        return SuperDict(
-            {k: func(v, other[k], *args, **kwargs) for k, v in self.items()}
-        )
+        return self.kvapply(lambda k, v: func(v, other[k], *args, **kwargs))
 
     def get_m(self, *args, default=None) -> Any:
         """

--- a/pytups/superdict.py
+++ b/pytups/superdict.py
@@ -56,6 +56,12 @@ class SuperDict(dict, Generic[K, V], Mapping[K, V]):
     # def __rmul__(self, other):
     #     return self.sapply(op.__mul__, other)
 
+    def __truediv__(self, other):
+        return self.sapply(op.__truediv__, other)
+
+    def __floordiv__(self, other):
+        return self.sapply(op.__floordiv__, other)
+
     def head(self):
         if len(self) <= 2:
             return dict.__repr__(self)
@@ -454,16 +460,21 @@ class SuperDict(dict, Generic[K, V], Mapping[K, V]):
         """
         return SuperDict({k: func(k, *args, **kwargs) for k in self})
 
-    def sapply(self, func: Callable, other: dict, *args, **kwargs) -> "SuperDict":
+    def sapply(
+        self, func: Callable, other: Union[dict, int, float], *args, **kwargs
+    ) -> "SuperDict":
         """
         Applies function to both dictionaries.
         Using keys of the self.
         It's like applying a function over the left join.
 
         :param callable func: function to apply.
-        :param dict other: dictionary to apply function to
+        :param Union[dict, int, float] other: either ar int or float to perform the operation over or another dictionary
         :return: new :py:class:`SuperDict`
         """
+        if isinstance(other, (int, float)):
+            other = {k: other for k in self}
+
         return SuperDict(
             {k: func(v, other[k], *args, **kwargs) for k, v in self.items()}
         )

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -462,6 +462,86 @@ class DictTest(unittest.TestCase):
             self.fail(e)
         self.assertEqual(a, {"y": {"x": 1}})
 
+    def test_add_dicts(self):
+        a = self.dict_class({"a": 1})
+        b = self.dict_class({"a": 2, "b": 1})
+        c = a + b
+        self.assertEqual(c, {"a": 3})
+
+    def test_add_int(self):
+        a = self.dict_class({"a": 1, "b": 5})
+        c = a + 2
+        self.assertEqual(c, {"a": 3, "b": 7})
+
+    def test_add_flaot(self):
+        a = self.dict_class({"a": 1, "b": 5})
+        c = a + 2.5
+        self.assertEqual(c, {"a": 3.5, "b": 7.5})
+
+    def test_subtract_dict(self):
+        a = self.dict_class({"a": 1})
+        b = self.dict_class({"a": 2})
+        c = a - b
+        self.assertEqual(c, {"a": -1})
+
+    def test_subtract_int(self):
+        a = self.dict_class({"a": 1, "b": 1})
+        c = a - 1
+        self.assertEqual(c, {"a": 0, "b": 0})
+
+    def test_subtract_float(self):
+        a = self.dict_class({"a": 1, "b": 1})
+        c = a - 1.5
+        self.assertEqual(c, {"a": -0.5, "b": -0.5})
+
+    def test_multiply_dicts(self):
+        a = self.dict_class({"a": 1})
+        b = self.dict_class({"a": 2})
+        c = a * b
+        self.assertEqual(c, {"a": 2})
+
+    def test_multiply_int(self):
+        a = self.dict_class({"a": 1, "b": -1})
+        c = a * 2
+        self.assertEqual(c, {"a": 2, "b": -2})
+
+    def test_multiply_float(self):
+        a = self.dict_class({"a": 1, "b": 5})
+        c = a * 2.5
+        self.assertEqual(c, {"a": 2.5, "b": 12.5})
+
+    def test_divide_dicts(self):
+        a = self.dict_class({"a": 4})
+        b = self.dict_class({"a": 2})
+        c = a / b
+        self.assertEqual(c, {"a": 2})
+
+    def test_divide_int(self):
+        a = self.dict_class({"a": 4, "b": 4})
+        c = a / 3
+        self.assertEqual(c, {"a": 4 / 3, "b": 4 / 3})
+
+    def test_divide_float(self):
+        a = self.dict_class({"a": 4, "b": 6})
+        c = a / 3.0
+        self.assertEqual(c, {"a": 4 / 3.0, "b": 6 / 3.0})
+
+    def test_integer_div_dicts(self):
+        a = self.dict_class({"a": 4})
+        b = self.dict_class({"a": 3, "b": 1})
+        c = a // b
+        self.assertEqual(c, {"a": 1})
+
+    def test_integer_div_int(self):
+        a = self.dict_class({"a": 4, "b": 6})
+        c = a // 3
+        self.assertEqual(c, {"a": 1, "b": 2})
+
+    def test_integer_div_float(self):
+        a = self.dict_class({"a": 4, "b": 7})
+        c = a // 3.5
+        self.assertEqual(c, {"a": 1, "b": 2})
+
     def setUp(self):
         pass
 

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -473,7 +473,7 @@ class DictTest(unittest.TestCase):
         c = a + 2
         self.assertEqual(c, {"a": 3, "b": 7})
 
-    def test_add_flaot(self):
+    def test_add_float(self):
         a = self.dict_class({"a": 1, "b": 5})
         c = a + 2.5
         self.assertEqual(c, {"a": 3.5, "b": 7.5})
@@ -541,6 +541,43 @@ class DictTest(unittest.TestCase):
         a = self.dict_class({"a": 4, "b": 7})
         c = a // 3.5
         self.assertEqual(c, {"a": 1, "b": 2})
+
+    def test_add_strings(self):
+        a = self.dict_class({"a": "a"})
+        b = self.dict_class({"a": "b"})
+        c = a + b
+        self.assertEqual(c, {"a": "ab"})
+
+    def test_add_lists(self):
+        a = self.dict_class({"a": [1]})
+        b = self.dict_class({"a": [2]})
+        c = a + b
+        self.assertEqual(c, {"a": [1, 2]})
+
+    def test_add_int_to_list(self):
+        a = self.dict_class({"a": [1]})
+        lambda_add = lambda a: a + 2
+        self.assertRaises(TypeError, lambda_add, a)
+
+    def test_add_int_to_string(self):
+        a = self.dict_class({"a": "a"})
+        lambda_add = lambda a: a + 2
+        self.assertRaises(TypeError, lambda_add, a)
+
+    def test_add_str_to_int(self):
+        a = self.dict_class({"a": 2})
+        lambda_add = lambda a: a + "2"
+        self.assertRaises(TypeError, lambda_add, a)
+
+    def test_multiply_string_into_int(self):
+        a = self.dict_class({"a": "a"})
+        c = a * 2
+        self.assertEqual(c, {"a": "aa"})
+
+    def test_multiply_int_to_string(self):
+        a = self.dict_class({"a": 2})
+        c = a * "2"
+        self.assertEqual(c, {"a": "22"})
 
     def setUp(self):
         pass


### PR DESCRIPTION
Modified the behaviour of some basic arithmetic operators  so they accept also int or float values

Added true division and integer division as well.

The main idea es that now we can do the following operation:

``` python

from pytups import SuperDict

d1 = SuperDict({"a": 1, "b": 2})

d2 = d1 + 3

print(d2)
# {"a": 4, "b": 5}
```

I know this operation can also be done as:

``` python

d1 = d1.vapply(lambda v: v+3)

```

But as we can also do direct operations on dicts: `d1 + d2` or `d1 * d2` it seem natural to have as well `d1 + 3` as an option.

This has been applied to subtraction and multiplication, plus true division and integer division has been added.

I have added all the pertinent tests (I think), but tell me what you think about this change and if you think it has place on the library.

PS:

The change to `__sapply__` can also be done the following way:

```python

if isinstance(other, (int, float):
  return SuperDict({k: func(v, other, *args, **kwargs) for k, v in self.items()})

 ```